### PR TITLE
Fix: Add /dev/net/tun device to Docker Compose config for OpenVPN compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,30 @@
+## [2.1.1] - 2025-01-03
+
+- Add /dev/net/tun device to Docker Compose config for OpenVPN compatibility. Recent changes in Docker require explicitly mounting the /dev/net/tun device to ensure proper operation of OpenVPN. Updated docker-compose.yml to include this configuration.
+
+## [2.1.0] - 2024-04-16
+
+- Change DockerOVPN source for the one forked by nimbux which also contains Openvpn community 2.6.8
+- Add "EASYRSA_BATCH=1" hardcoded variable to docker-compose to allow for auto-run in the initpki script
+
 ## [2.0.0] - 2023-10-04
 
-### Changed
+- Replace s3 persistent storage with EBS volume
+- Replace launch configuration with launch template
+- Update Docker version
+- Add useful outputs
+- Add default values and types for most inputs
+- Add tags
+- Add fixed version of the openvpn docker image
 
-- s3 persistent storage replaced by ebs volume
-- Inputs
-- Launch configuration replaced by Launch template
-- Docker version updated
+## [1.1.0] - 2024-07-19
 
-### Added
-
-- Useful outputs.
-- Default values and types for most inputs.
-- tags.
-- Fixed version of the openvpn docker image.
+- Add tags input
 
 ## [1.0.1] - 2022-07-29
 
-### Added
-
-- Outputs.tf file with security group id.
+- Add outputs.tf file with security group id.
 
 ## [1.0.0] - 2022-07-21
-
-### Added
 
 - First version of the OpenVPN module.

--- a/resources/templates/docker-compose.yaml.tpl
+++ b/resources/templates/docker-compose.yaml.tpl
@@ -3,6 +3,8 @@ services:
   openvpn:
     cap_add:
      - NET_ADMIN
+    devices:
+      - /dev/net/tun:/dev/net/tun
     image: public.ecr.aws/n5x5g3h7/nimbux911/dockovpn:2.6.8-config.0.1.0
     container_name: openvpn
     ports:


### PR DESCRIPTION
Recent changes in Docker require explicitly mounting the /dev/net/tun device to ensure proper operation of OpenVPN. Updated docker-compose.yml to include this configuration.